### PR TITLE
Move category macros to shared file

### DIFF
--- a/forms/addArticleForm.twig
+++ b/forms/addArticleForm.twig
@@ -1,71 +1,3 @@
-{#
-    Vykreslení kategorií rozdělených podle navigace. V rámci každé navigace jsou
-    kategorie seřazeny dle "order_cat" a zachovává se jejich zanoření.
-#}
-{% macro renderCategoryList(categories, selectedCategories) %}
-    {% import _self as self %}
-    <ul class="list-disc ml-6 space-y-2">
-    {% for category in categories|sort(attribute='order_cat') %}
-        {% if category.meta.listArticles == "false" %}
-            {% set isChecked = false %}
-            {% for selectedCategory in selectedCategories %}
-                {% if selectedCategory.id == category.id %}
-                    {% set isChecked = true %}
-                {% endif %}
-            {% endfor %}
-            <li class="ml-5">
-                <input type="checkbox" id="category_{{ category.id }}" name="categories[]" value="{{ category.id }}" {{ isChecked ? 'checked' : '' }}>
-                <label for="category_{{ category.id }}" data-url="{{ category.url }}" data-id="{{ category.id }}" style="cursor: pointer;" class="no-select">{{ category.title }}</label>
-                {% if category.children|length > 0 %}
-                    {{ self.renderCategoryList(category.children, selectedCategories) }}
-                {% endif %}
-            </li>
-        {% endif %}
-    {% endfor %}
-
-    {% for navId, navCats in groups %}
-        <div class="mb-2">
-            <h6>Navigace {{ navId }}</h6>
-            {{ self.renderCategoryList(navCats|sort((a,b) => a.order_cat <=> b.order_cat), selectedCategories) }}
-        </div>
-    {% endfor %}
-{% endmacro %}
-
-
-
-{% macro renderNavigationGroups(categories, selectedCategories) %}
-    {% import _self as self %}
-    {% set groups = {} %}
-    {% for cat in categories %}
-        {% set navId = cat.navigation_id %}
-        {% if groups[navId] is not defined %}
-            {% set groups = groups | merge({ (navId): [] }) %}
-        {% endif %}
-        {% set groups = groups | merge({ (navId): groups[navId] | merge([cat]) }) %}
-    {% endfor %}
-    {% for navId, navCats in groups %}
-        <div class="mb-2">
-            <h6>Navigace {{ navId }}</h6>
-            {{ self.renderCategoryList(navCats|sort((a,b) => a.order_cat <=> b.order_cat), selectedCategories) }}
-        </div>
-    {% endfor %}
-{% endmacro %}
-
-{% macro renderCategoryCheckboxes(categories, selectedCategories) %}
-    {% import _self as self %}
-    {# Seskupeni kategorii podle navigation_id #}
-    {% set navGroups = {} %}
-    {% for cat in categories %}
-        {% set navGroups = navGroups|merge({ (cat.navigation_id): (navGroups[cat.navigation_id]|default([]))|merge([cat]) }) %}
-    {% endfor %}
-
-    {% for navId, navCategories in navGroups %}
-        <div class="mb-2">
-            <h6>Navigace {{ navId }}</h6>
-            {{ self.renderCategoryList(navCategories, selectedCategories) }}
-        </div>
-    {% endfor %}
-{% endmacro %}
 
 <style>
 .medium-editor-element h1{
@@ -295,7 +227,7 @@
 
                 <div class="mb-3">
                     <h5>Vyberte kategorii</h5>
-                    {% import _self as macros %}
+                    {% import 'forms/macros/categories.twig' as macros %}
                     {{ macros.renderNavigationGroups(pageData.allCats, pageData.article.categories) }}
                     <p>Dvojkliknutím na název kategorie vytvoříte url článku s použitím url kategorie.</p>
                 </div>

--- a/forms/addPageForm.twig
+++ b/forms/addPageForm.twig
@@ -1,24 +1,3 @@
-{% macro renderCategoryCheckboxes(categories, selectedCategories) %}
-    {% import _self as self %}
-    <ul>
-    {% for category in categories %}
-        {% set isChecked = false %}
-        {% for selectedCategory in selectedCategories %}
-            {% if selectedCategory.id == category.id %}
-                {% set isChecked = true %}
-            {% endif %}
-        {% endfor %}
-        <li>
-            <input type="checkbox" id="category_{{ category.id }}" name="categories[]" value="{{ category.id }}" {{ isChecked ? 'checked' : '' }}>
-            <label for="category_{{ category.id }}">{{ category.title }} {{ category.id }}</label>
-            {% if category.children|length > 0 %}
-                {{ self.renderCategoryCheckboxes(category.children, selectedCategories) }}
-            {% endif %}
-        </li>
-    {% endfor %}
-    </ul>
-{% endmacro %}
-
 <style>
 </style>
 <form id="articleForm" method="post" action="{{ domainData.SITE_WEB }}/admin/doArticle">
@@ -118,7 +97,7 @@
             <div class="col-md-5">
                 <div class="mb-3">
                     <label for="categorySelect" class="form-label">Vyberte kategorie:</label>
-                    {% import _self as macros %}
+                    {% import 'forms/macros/categories.twig' as macros %}
                     {{ macros.renderCategoryCheckboxes(pageData.allCats, pageData.article.categories) }}
                 </div>
             </div>

--- a/forms/macros/categories.twig
+++ b/forms/macros/categories.twig
@@ -1,0 +1,63 @@
+{# Macros for rendering categories #}
+
+{% macro renderCategoryCheckboxes(categories, selectedCategories) %}
+    {% import _self as self %}
+    <ul>
+    {% for category in categories %}
+        {% set isChecked = false %}
+        {% for selectedCategory in selectedCategories %}
+            {% if selectedCategory.id == category.id %}
+                {% set isChecked = true %}
+            {% endif %}
+        {% endfor %}
+        <li>
+            <input type="checkbox" id="category_{{ category.id }}" name="categories[]" value="{{ category.id }}" {{ isChecked ? 'checked' : '' }}>
+            <label for="category_{{ category.id }}">{{ category.title }} {{ category.id }}</label>
+            {% if category.children|length > 0 %}
+                {{ self.renderCategoryCheckboxes(category.children, selectedCategories) }}
+            {% endif %}
+        </li>
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+{% macro renderCategoryList(categories, selectedCategories) %}
+    {% import _self as self %}
+    <ul class="list-disc ml-6 space-y-2">
+    {% for category in categories|sort(attribute='order_cat') %}
+        {% if category.meta.listArticles == "false" %}
+            {% set isChecked = false %}
+            {% for selectedCategory in selectedCategories %}
+                {% if selectedCategory.id == category.id %}
+                    {% set isChecked = true %}
+                {% endif %}
+            {% endfor %}
+            <li class="ml-5">
+                <input type="checkbox" id="category_{{ category.id }}" name="categories[]" value="{{ category.id }}" {{ isChecked ? 'checked' : '' }}>
+                <label for="category_{{ category.id }}" data-url="{{ category.url }}" data-id="{{ category.id }}" style="cursor: pointer;" class="no-select">{{ category.title }}</label>
+                {% if category.children|length > 0 %}
+                    {{ self.renderCategoryList(category.children, selectedCategories) }}
+                {% endif %}
+            </li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+{% macro renderNavigationGroups(categories, selectedCategories) %}
+    {% import _self as self %}
+    {% set groups = {} %}
+    {% for cat in categories %}
+        {% set navId = cat.navigation_id %}
+        {% if groups[navId] is not defined %}
+            {% set groups = groups | merge({ (navId): [] }) %}
+        {% endif %}
+        {% set groups = groups | merge({ (navId): groups[navId] | merge([cat]) }) %}
+    {% endfor %}
+    {% for navId, navCats in groups %}
+        <div class="mb-2">
+            <h6>Navigace {{ navId }}</h6>
+            {{ self.renderCategoryList(navCats|sort((a,b) => a.order_cat <=> b.order_cat), selectedCategories) }}
+        </div>
+    {% endfor %}
+{% endmacro %}


### PR DESCRIPTION
## Summary
- extract macros that render categories into a new file `forms/macros/categories.twig`
- import this new macros file in `addArticleForm.twig` and `addPageForm.twig`

## Testing
- `true`